### PR TITLE
[OT149-78] Endpoint Eliminación Comentarios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/v1/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/CommentController.java
@@ -1,12 +1,22 @@
 package com.alkemy.ong.controller.v1;
 
 import com.alkemy.ong.dto.CommentDto;
+import com.alkemy.ong.exception.ErrorDetails;
 import com.alkemy.ong.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -31,5 +41,21 @@ public class CommentController {
 		final long id = service.saveComment(dto);
 		UriComponents uriComponents = uriComponentsBuilder.path(V_1_COMMENTS + "/{id}").buildAndExpand(id);
 		return ResponseEntity.created(uriComponents.toUri()).build();
+	}
+
+	@Operation(summary = "Delete a comment by its id")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "204", description = "Comment deleted",
+					content = @Content),
+			@ApiResponse(responseCode = "403", description = "Without permission",
+					content = @Content),
+			@ApiResponse(responseCode = "404", description = "Comment not found",
+					content = { @Content(mediaType = "application/json",
+							schema = @Schema(implementation = ErrorDetails.class)) })
+	})
+	@DeleteMapping("/{id}")
+	@ResponseStatus(value = HttpStatus.NO_CONTENT, reason = "Comment deleted.")
+	public void deleteComment(@PathVariable Long id){
+		service.deleteComment(id);
 	}
 }

--- a/src/main/java/com/alkemy/ong/exception/CommentNotFoundException.java
+++ b/src/main/java/com/alkemy/ong/exception/CommentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.alkemy.ong.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Comment not found.")
+public class CommentNotFoundException extends RuntimeException{
+}

--- a/src/main/java/com/alkemy/ong/service/CommentService.java
+++ b/src/main/java/com/alkemy/ong/service/CommentService.java
@@ -5,4 +5,5 @@ import com.alkemy.ong.dto.CommentDto;
 public interface CommentService {
 
 	Long saveComment(CommentDto dto);
+	void deleteComment(Long id);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.CommentDto;
+import com.alkemy.ong.exception.CommentNotFoundException;
 import com.alkemy.ong.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 import com.alkemy.ong.mapper.CommentMapper;

--- a/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
@@ -1,6 +1,9 @@
 package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.CommentDto;
+import com.alkemy.ong.exception.CommentNotFoundException;
+import com.alkemy.ong.exception.NewNotFoundException;
+import com.alkemy.ong.exception.NotFoundException;
 import com.alkemy.ong.mapper.CommentMapper;
 import com.alkemy.ong.model.Comment;
 import com.alkemy.ong.repository.CommentRepository;
@@ -29,5 +32,12 @@ public class CommentServiceImpl implements CommentService {
 			Comment comment = mapper.toComment(dto);
 			repository.save(comment);
 			return comment.getId();
+	}
+
+	public void deleteComment(Long id) {
+		if (repository.findById(id).isEmpty()) {
+			throw new CommentNotFoundException();
+		}
+		repository.deleteById(id);
 	}
 }


### PR DESCRIPTION
## Summary
- JIRA Ticket 78
- Criterios de aceptación:
DELETE /comments/:id - Deberá validar la existencia del comentario. Solamente podrán eliminar un comentario el usuario creador del mismo o un administrador. Deberá devolver un código de error 404 si el comentario no existe, o 403 si no tiene permiso para modificarlo.
-->

### Type of change
- [x] New feature
- [ ] New Tests
- [ ] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
