### PR TITLE
[OT149-105] Added @SecurityRequirement to all Controllers except AuthController

### DIFF
--- a/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf().disable()
-                .authorizeRequests().antMatchers("/v1/auth/*","/api/docs/**","/api/swagger-ui/**","/v3/api-docs/**").permitAll()
+                .authorizeRequests().antMatchers("/v1/auth/register","/v1/auth/login","/api/docs/**","/api/swagger-ui/**","/v3/api-docs/**").permitAll()
                 .antMatchers(HttpMethod.POST, "/v1/**").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE, "/v1/**").hasRole("ADMIN")
                 .antMatchers(HttpMethod.PUT, "/v1/**").hasRole("ADMIN")

--- a/src/main/java/com/alkemy/ong/controller/v1/ActivityController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/ActivityController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,7 @@ import static com.alkemy.ong.controller.ControllerConstants.REQ_MAPP_ACTIVITIES;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(REQ_MAPP_ACTIVITIES)
+@SecurityRequirement(name = "bearerAuth")
 public class ActivityController {
 
     @Autowired
@@ -40,7 +42,10 @@ public class ActivityController {
                     content = @Content),
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
              })
     @PostMapping()
     public ResponseEntity<Void> addActivity(UriComponentsBuilder uriComponentsBuilder, @Valid @RequestBody ActivityDto dto) {
@@ -61,9 +66,13 @@ public class ActivityController {
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Invalid id supplied",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+
     })
     @PutMapping("/{id}")
     public ResponseEntity<ActivityDto> updateActivity(@PathVariable Long id, @Valid @RequestBody ActivityDto dto) {

--- a/src/main/java/com/alkemy/ong/controller/v1/AuthController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/AuthController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -42,8 +43,8 @@ public class AuthController {
             @ApiResponse(responseCode = "201", description = "Create user",
                     content = @Content),
             @ApiResponse(responseCode = "400", description = "Invalid field",
-                    content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PostMapping("/register")
     public ResponseEntity<UserResponseDto> saveUser(@Valid @RequestBody RegisterRequest user) {
@@ -51,16 +52,18 @@ public class AuthController {
     }
 
 
-
-    @Operation(summary = "Get an user")
+    @Operation(summary = "Get an user", security = @SecurityRequirement(name = "bearerAuth"))
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Found the user",
-                    content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = UserDto.class)) }),
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserDto.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "User not found",
-                    content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
-            })
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
+    })
 
     @GetMapping("/me")
     public ResponseEntity<UserDto> userLogged() {
@@ -77,14 +80,14 @@ public class AuthController {
     @Operation(summary = "Login a user")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User successfully logged in",
-                    content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = AuthenticationResponse.class)) }),
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthenticationResponse.class))}),
             @ApiResponse(responseCode = "401", description = "User not logged in",
-                    content = { @Content(mediaType = "application/json",
+                    content = {@Content(mediaType = "application/json",
                             schema = @Schema(
                                     example = "{\n\"ok\": false\n}",
                                     type = "boolean",
-                                    description = "false if User not logged in")) })
+                                    description = "false if User not logged in"))})
     })
 
     @PostMapping("/login")

--- a/src/main/java/com/alkemy/ong/controller/v1/CategoryController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/CategoryController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import com.alkemy.ong.service.CategoryService;
@@ -41,6 +42,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_CATEGORIES;
 @RestController
 @RequestMapping(V_1_CATEGORIES)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class CategoryController {
     @Autowired
     private final CategoryService service;
@@ -52,7 +54,10 @@ public class CategoryController {
                             schema = @Schema(implementation = CategoryDetailDto.class)) }),
             @ApiResponse(responseCode = "404", description = "Category not found",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @GetMapping("/{id}")
     public ResponseEntity<CategoryDetailDto>getCategoryById(@PathVariable Long id){
@@ -65,9 +70,13 @@ public class CategoryController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Delete the category",
                     content = @Content),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Category not found",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+
     })
     @DeleteMapping("/{id}")
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
@@ -82,7 +91,10 @@ public class CategoryController {
                     content = @Content),
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_UTF8_VALUE})
     public ResponseEntity<Void> createCategory(UriComponentsBuilder uriComponentsBuilder, @Valid @RequestBody CategoryDto dto){
@@ -99,6 +111,9 @@ public class CategoryController {
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Invalid id supplied",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) })
@@ -114,7 +129,10 @@ public class CategoryController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Retrieve a list of categories",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = CategoryListDto.class)) })
+                            schema = @Schema(implementation = CategoryListDto.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @GetMapping
     public ResponseEntity<List<CategoryListDto>>getCategoryList(){

--- a/src/main/java/com/alkemy/ong/controller/v1/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/CommentController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
@@ -36,6 +37,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_COMMENTS;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(V_1_COMMENTS)
+@SecurityRequirement(name = "bearerAuth")
 public class CommentController {
 
 	private final CommentService service;
@@ -66,8 +68,9 @@ public class CommentController {
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "204", description = "Comment deleted",
 					content = @Content),
-			@ApiResponse(responseCode = "403", description = "Without permission",
-					content = @Content),
+			@ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+					content = {@Content(mediaType = "application/json",
+							schema = @Schema(implementation = ErrorDetails.class))}),
 			@ApiResponse(responseCode = "404", description = "Comment not found",
 					content = { @Content(mediaType = "application/json",
 							schema = @Schema(implementation = ErrorDetails.class)) })
@@ -82,6 +85,9 @@ public class CommentController {
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "Success",
 					content = @Content),
+			@ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+					content = {@Content(mediaType = "application/json",
+							schema = @Schema(implementation = ErrorDetails.class))})
 	})
 	@GetMapping("/posts/{id}")
 	public ResponseEntity<List<CommentDto>> getAllCommentsByPost(@PathVariable Long id){

--- a/src/main/java/com/alkemy/ong/controller/v1/ContactController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/ContactController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_CONTACTS;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(V_1_CONTACTS)
+@SecurityRequirement(name = "bearerAuth")
 public class ContactController {
 
     private final ContactService contactService;
@@ -46,7 +48,10 @@ public class ContactController {
                             schema = @Schema(implementation = ContactDto.class)) }),
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class)) })
+                            schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PostMapping
     public ResponseEntity<ContactDto> saveContact(@Valid @RequestBody ContactDto dto) {
@@ -65,7 +70,10 @@ public class ContactController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Retrieve a list of contacts",
                     content = { @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ContactDto.class)) })
+                            schema = @Schema(implementation = ContactDto.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping

--- a/src/main/java/com/alkemy/ong/controller/v1/ImageUploadController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/ImageUploadController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_IMAGES_UPLOAD;
 @RestController
 @RequestMapping(V_1_IMAGES_UPLOAD)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class ImageUploadController {
 
 	private final AmazonS3Service service;
@@ -34,7 +36,10 @@ public class ImageUploadController {
 							schema = @Schema(implementation = String.class)) }),
 			@ApiResponse(responseCode = "400", description = "Invalid field",
 					content = { @Content(mediaType = "application/json",
-							schema = @Schema(implementation = ErrorDetails.class)) })
+							schema = @Schema(implementation = ErrorDetails.class)) }),
+			@ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+					content = {@Content(mediaType = "application/json",
+							schema = @Schema(implementation = ErrorDetails.class))})
 	})
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/alkemy/ong/controller/v1/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,12 +35,22 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_MEMBERS;
 @RestController
 @RequestMapping(V_1_MEMBERS)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class MemberController {
 
     private final MemberServiceImpl memberService;
 
     @Operation(summary = "Get a member list")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Retrieve a list of members", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberDto.class))})})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Retrieve a list of members",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = MemberDto.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
+    })
+
+
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping
     public ResponseEntity<MemberPagedList> list(
@@ -75,7 +86,19 @@ public class MemberController {
     }
 
     @Operation(summary = "Update member")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Update member", content = @Content), @ApiResponse(responseCode = "400", description = "Invalid field", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDetails.class))}), @ApiResponse(responseCode = "404", description = "Invalid id supplied", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDetails.class))})})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Update member",
+                    content = @Content),
+            @ApiResponse(responseCode = "400", description = "Invalid field",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "404", description = "Invalid id supplied",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
+    })
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/{id}")
     public void updateMember(@PathVariable Integer id, @Valid @RequestBody MemberDto dto) {
@@ -83,7 +106,15 @@ public class MemberController {
     }
 
     @Operation(summary = "Delete a member by its id")
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Delete the member", content = @Content), @ApiResponse(responseCode = "404", description = "Member not found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDetails.class))})})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Delete the member",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "404", description = "Member not found",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})})
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")
     public void deleteMember(@PathVariable Integer id) {
@@ -91,7 +122,16 @@ public class MemberController {
     }
 
     @Operation(summary = "Add a new member to the database")
-    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Create member", content = @Content), @ApiResponse(responseCode = "400", description = "Invalid field", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDetails.class))})})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Create member",
+                    content = @Content),
+            @ApiResponse(responseCode = "400", description = "Invalid field",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
+    })
     @PostMapping
     public ResponseEntity<Void> addMember(UriComponentsBuilder uriComponentsBuilder, @Valid @RequestBody
             MemberDto dto) {

--- a/src/main/java/com/alkemy/ong/controller/v1/NewController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/NewController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,20 +35,24 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_NEWS;
 @RestController
 @RequestMapping(V_1_NEWS)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class NewController {
     private final NewService service;
 
     @Operation(summary = "Get New by id.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "New found.",
-            content = {@Content(mediaType = "application/json",
-            schema = @Schema(implementation = NewDetailDto.class))}),
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NewDetailDto.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "New not found.",
-            content = {@Content(mediaType = "application/json",
-            schema = @Schema(implementation = ErrorDetails.class))})
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @GetMapping("/{id}")
-    public ResponseEntity<NewDetailDto>getNewById(@PathVariable Long id){
+    public ResponseEntity<NewDetailDto> getNewById(@PathVariable Long id) {
         NewDetailDto detailNew = service.getNewById(id);
         return ResponseEntity.ok().body(detailNew);
     }
@@ -55,28 +60,34 @@ public class NewController {
     @Operation(summary = "Update New by id.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Updated New.",
-            content = {@Content(mediaType = "application/json",
-            schema = @Schema(implementation = NewDto.class))}),
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = NewDto.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "New not found.",
-            content = {@Content(mediaType = "application/json",
-            schema = @Schema(implementation = ErrorDetails.class))})
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PutMapping("/{id}")
-	public ResponseEntity<NewDetailDto> saveOrUpdateNews(@RequestBody NewDto news, @PathVariable(value="id") Long id ){
+    public ResponseEntity<NewDetailDto> saveOrUpdateNews(@RequestBody NewDto news, @PathVariable(value = "id") Long id) {
 
-		return new ResponseEntity<NewDetailDto>(service.addNews(news,id),HttpStatus.CREATED);
-	}
+        return new ResponseEntity<NewDetailDto>(service.addNews(news, id), HttpStatus.CREATED);
+    }
 
     @Operation(summary = "Create New.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Created New",
-            content = @Content),
+                    content = @Content),
             @ApiResponse(responseCode = "400", description = "Field cannot be empty.",
-            content = {@Content(mediaType = "application/json",
-            schema = @Schema(implementation = ErrorDetails.class))})
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))})
     })
     @PostMapping(consumes = {MediaType.APPLICATION_JSON_UTF8_VALUE})
-    public ResponseEntity<Void> createNew (UriComponentsBuilder uriComponentsBuilder, @Valid @RequestBody NewDto dto){
+    public ResponseEntity<Void> createNew(UriComponentsBuilder uriComponentsBuilder, @Valid @RequestBody NewDto dto) {
         final long newId = service.createNew(dto);
         UriComponents uriComponents = uriComponentsBuilder.path("/{id}").buildAndExpand(newId);
         return ResponseEntity.created(uriComponents.toUri()).build();
@@ -86,29 +97,29 @@ public class NewController {
     @GetMapping
     public ResponseEntity<NewPagedList> list(@RequestParam(value = "pageNumber", required = false) Integer pageNumber,
                                              @RequestParam(value = "pageSize", required = false) Integer pageSize,
-                                             UriComponentsBuilder uriComponentsBuilder){
-        if (pageNumber == null || pageNumber < 0){
+                                             UriComponentsBuilder uriComponentsBuilder) {
+        if (pageNumber == null || pageNumber < 0) {
             pageNumber = ControllerConstants.DEFAULT_PAGE_NUMBER;
         }
-        if (pageSize == null || pageSize < 1){
+        if (pageSize == null || pageSize < 1) {
             pageSize = ControllerConstants.DEFAULT_PAGE_SIZE;
         }
         UriComponentsBuilder uriBuilder = uriComponentsBuilder.path(V_1_NEWS).queryParam("pageNumber={page}");
         NewPagedList pagedList = service.pagedList(PageRequest.of(pageNumber, pageSize));
-        if (pagedList.hasNext()){
+        if (pagedList.hasNext()) {
             pagedList.setNextUri(uriBuilder.buildAndExpand(pageNumber + 1).toUri());
-        }else {
+        } else {
             pagedList.setNextUri(uriBuilder.buildAndExpand(pageNumber).toUri());
         }
-        if (pagedList.hasPrevious()){
+        if (pagedList.hasPrevious()) {
             pagedList.setBackUri(uriBuilder.buildAndExpand(pageNumber - 1).toUri());
-        }else {
+        } else {
             pagedList.setBackUri(uriBuilder.buildAndExpand(pageNumber).toUri());
         }
 
         return ResponseEntity.ok(pagedList);
     }
-    
+
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")
     public void deleteNew(@PathVariable Long id) {

--- a/src/main/java/com/alkemy/ong/controller/v1/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/OrganizationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_ORG;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(V_1_ORG)
+@SecurityRequirement(name = "bearerAuth")
 public class OrganizationController {
 
     private final OrganizationService service;
@@ -35,6 +37,9 @@ public class OrganizationController {
             @ApiResponse(responseCode = "200", description = "Found the organization",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = OrganizationResponseDto.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Organization not found",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) })
@@ -51,6 +56,9 @@ public class OrganizationController {
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) }),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Invalid id supplied",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) })

--- a/src/main/java/com/alkemy/ong/controller/v1/SlideController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/SlideController.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.controller.v1;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import org.springframework.web.bind.annotation.PutMapping;
 
 import static com.alkemy.ong.controller.ControllerConstants.V_1_SLIDES;
@@ -29,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping(V_1_SLIDES)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class SlideController {
   
     private final SlideService service;

--- a/src/main/java/com/alkemy/ong/controller/v1/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/TestimonialController.java
@@ -55,9 +55,13 @@ public class TestimonialController {
             @ApiResponse(responseCode = "400", description = "Invalid field",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Invalid id supplied",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class))})
+
     })
     @PutMapping("/{id}")
     public TestimonialDto update(
@@ -70,6 +74,9 @@ public class TestimonialController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Create testimonial"),
             @ApiResponse(responseCode = "400", description = "Invalid field",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class))})
     })
@@ -116,12 +123,12 @@ public class TestimonialController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Delete testimonial",
                     content = @Content),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Testimonial not found",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class))}),
-            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
-                    content = {@Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ErrorDetails.class))})
 
     })
     @PreAuthorize("hasRole('ROLE_ADMIN')")

--- a/src/main/java/com/alkemy/ong/controller/v1/UserController.java
+++ b/src/main/java/com/alkemy/ong/controller/v1/UserController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,7 @@ import static com.alkemy.ong.controller.ControllerConstants.V_1_USERS;
 @RestController
 @RequestMapping(V_1_USERS)
 @RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
 
     private final UserService service;
@@ -47,6 +49,9 @@ public class UserController {
             @ApiResponse(responseCode = "204", description = "Update user",
                     content = @Content),
             @ApiResponse(responseCode = "400", description = "Invalid field",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
                     content = {@Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "Invalid id supplied",
@@ -82,6 +87,9 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Delete the user",
                     content = @Content),
+            @ApiResponse(responseCode = "403", description = "Invalid token or token expired | Accessing with invalid role",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorDetails.class))}),
             @ApiResponse(responseCode = "404", description = "User not found",
                     content = { @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ErrorDetails.class)) })

--- a/src/test/java/com/alkemy/ong/controller/v1/UserControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/v1/UserControllerTest.java
@@ -86,13 +86,13 @@ class UserControllerTest {
     @Test
     void list_shouldRespond200() throws Exception {
 
-        final UserDto user1 = UserDto.builder()
+        final UserPatchDTO user1 = UserPatchDTO.builder()
                 .firstName("John")
                 .lastName("Foo")
                 .photo("foo.jpg")
                 .build();
 
-        final UserDto user2 = UserDto.builder()
+        final UserPatchDTO user2 = UserPatchDTO.builder()
                 .firstName("Jane")
                 .lastName("Bar")
                 .photo("bar.jpg")


### PR DESCRIPTION
## Summary
- Added ```@SecurityRequirement( name = "bearerAuth")``` to all Controllers except AuthController due It requires a token only on ```v1/auth/me``` endpoint . For this the ```securityRequirement``` is added on ```@Operation``` anotattion.
- Added ```@ApiResponse``` 403 (Invalid token or token expired | Invalid role ) to all Controllers documentation
- Fixed path ```.permitAll``` into SecurityConfig class. Now the request to ```/v1/auth/me``` will pass for the filter , on the other hand ```/v1/auth/register``` and ```v1/auth/login``` won't pass for it.

### Type of change
- [] New feature
- [ ] New Tests
- [x] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
