### PR TITLE
[OT149-102] Fixed: Error executing Comment seed

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,8 @@ spring.datasource.username=root
 
 spring.datasource.hikari.connectionTimeout=2000
 spring.jpa.database=mysql
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
 spring.datasource.hikari.maximum-pool-size=20
 spring.datasource.hikari.data-source-properties.cachePrepStmts=true
 spring.datasource.hikari.data-source-properties.prepStmtCacheSize=250


### PR DESCRIPTION
## Summary
- ```create-drop``` was changed to ```create``` on ```spring.jpa.hibernate.ddl-auto``` into ```application.properties```.That way, the error at starting the application will not apper. Now , the hibernate sequence is:
1.  The database tables are deleted at starting application
2.  Then the database tables are created again

- Added ```spring.jpa.properties.hibernate.show_sql=true``` into ```application.properties```. This allows check the sequence mentioned in the previous point.

### Type of change
- [ ] New feature
- [ ] New Tests
- [x] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
