### PR TITLE
[OT149-119] Fixed the issue that the user role cannot use the POST endpoint in ContactController

### DIFF
--- a/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/configuration/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf().disable()
                 .authorizeRequests().antMatchers("/v1/organizations/public/*", "/v1/slides/public/*", "/v1/auth/register","/v1/auth/login","/api/docs/**","/api/swagger-ui/**","/v3/api-docs/**").permitAll()
+                .antMatchers(HttpMethod.POST, "/v1/contacts").hasAnyRole("ADMIN", "USER")
                 .antMatchers(HttpMethod.POST, "/v1/**").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE, "/v1/**").hasRole("ADMIN")
                 .antMatchers(HttpMethod.PUT, "/v1/**").hasRole("ADMIN")

--- a/src/main/java/com/alkemy/ong/dto/ContactDto.java
+++ b/src/main/java/com/alkemy/ong/dto/ContactDto.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,7 +16,7 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ContactDto {
-
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private Long id;
 
     @NotBlank(message = "The name must not be empty")


### PR DESCRIPTION
## Summary
- Now the USER role can use the POST endpoint in ContactController
- Added ```@Schema(accessMode = Schema.AccessMode.READ_ONLY)``` to the ```id``` attribute in ContactDto
- Now the ```id``` field in ContactDto is not visible in the Swagger documentation when creating a new contact by POST

### Type of change
- [ ] New feature
- [ ] New Tests
- [x] Bug fix
- [ ] Refactor

### Checklist

- [ ] Traceability between this change and Jira.
- [ ] ```mvn clean install``` was run and all tests completed successfully.
- [ ] There are no unused variables and/or imports in the modified classes.
- [ ] There are no imports in the modified classes with the wildcard character. Ex: ```com.somepackage.*```.
- [ ] Slf4j was used for the application log instead ```System.out```.
- [ ] Public methods are documented with ```javadoc```.
